### PR TITLE
Update docker-machine to fix docker-compose bug

### DIFF
--- a/cookbooks/system/attributes/default.rb
+++ b/cookbooks/system/attributes/default.rb
@@ -1,5 +1,5 @@
 default[:users][:sudoer]        = "vagrant"
-default[:docker][:machine_vers] = "0.7.0"
+default[:docker][:machine_vers] = "0.12.0"
 
 default[:apt][:debs] = %w{
   apt-transport-https


### PR DESCRIPTION
I tried this project yesterday. The `web` container would not start, with docker-compose giving me  an obscure error:

```
==> default: * bash[run_brimir_docker] action run
==> default:
==> default:     [execute] brimir_db_1 is up-to-date
==> default:
==> default:               ERROR: for web  expected string or buffer
==> default:               Traceback (most recent call last):
==> default:                 File "/usr/local/bin/docker-compose", line 11, in <module>
==> default:
==> default:     sys.exit(main())
==> default:                 File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 68, in main
==> default:                   command()
==> default:                 File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 118, in perform_command
==> default:                   handler(command, command_options)
==> default:                 File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 926, in up
==> default:                   scale_override=parse_scale_args(options['--scale']),
==> default:                 File "/usr/local/lib/python2.7/dist-packages/compose/project.py", line 424, in up
==> default:                   get_deps
==> default:                 File "/usr/local/lib/python2.7/dist-packages/compose/parallel.py", line 69, in parallel_execute
==> default:                   raise error_to_reraise
==> default:               TypeError: expected string or buffer
==> default:
==> default:
==> default:
==> default: ================================================================================
==> default:
==> default: Error executing action `run` on resource 'bash[run_brimir_docker]'

```
The actual problem is the same as here: https://github.com/docker/compose/issues/4966

Updating docker-machine **seems** to fix the problem, but I haven't tested thoroughly.